### PR TITLE
bug-fixes: BigInt safety, RadixTrie fixes, README & examples updates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,8 @@ ip-kit/
 ├── tests/                 # Test files
 │   ├── core/              # Core utility tests
 │   └── domain/            # Domain model tests
+├── docs/                  # Documentation
+│   └── IP_CALCULATIONS.md # IP math and BigInt calculations guide
 ├── .github/               # GitHub configuration
 │   ├── workflows/         # CI/CD workflows
 │   └── prompts/           # Development prompts
@@ -125,7 +127,7 @@ ip-kit/
 ### Architecture Principles
 
 - **Type Safety**: Strict TypeScript with generics for version-specific operations
-- **BigInt Math**: All IP calculations use BigInt for precision
+- **BigInt Math**: All IP calculations use BigInt for precision (see [IP Calculations Guide](../docs/IP_CALCULATIONS.md))
 - **Lazy Evaluation**: Generators for memory-efficient iteration
 - **Error Handling**: Custom error classes for specific failure modes
 - **Modular Design**: Clear separation between core utilities and domain logic
@@ -212,18 +214,18 @@ git push origin feature/your-feature-name
 ### Writing Tests
 
 ```typescript
-import { describe, it, expect } from "vitest";
-import { IPv4 } from "../../src/domain/ip";
+import { describe, it, expect } from 'vitest';
+import { IPv4 } from '../../src/domain/ip';
 
-describe("IPv4", () => {
-  describe("parse", () => {
-    it("should parse valid IPv4 string", () => {
-      const ip = IPv4.parse("192.168.1.1");
-      expect(ip.toString()).toBe("192.168.1.1");
+describe('IPv4', () => {
+  describe('parse', () => {
+    it('should parse valid IPv4 string', () => {
+      const ip = IPv4.parse('192.168.1.1');
+      expect(ip.toString()).toBe('192.168.1.1');
     });
 
-    it("should throw on invalid input", () => {
-      expect(() => IPv4.parse("256.1.1.1")).toThrow();
+    it('should throw on invalid input', () => {
+      expect(() => IPv4.parse('256.1.1.1')).toThrow();
     });
   });
 });

--- a/README.md
+++ b/README.md
@@ -32,8 +32,19 @@ for (const host of network.hosts()) {
 }
 
 // Subnetting
-const subnets = Array.from(network.subnets(26));
-console.log(subnets.length); // 4
+// Prefer generator usage for large splits to avoid materializing large arrays:
+// Good (generator): iterate lazily
+let count = 0;
+for (const s of network.subnets(26)) {
+  count++;
+}
+console.log(count); // 4
+
+// Avoid using `split()` on very large networks — it returns an array and
+// can allocate millions of CIDR objects for IPv6-sized spaces.
+// If you really need all entries in memory, use `split()`:
+// const subnets = network.split(26);
+// console.log(subnets.length); // 4
 ```
 
 > 💡 **See more examples** in the [`examples/`](./examples/) directory!
@@ -42,8 +53,8 @@ console.log(subnets.length); // 4
 
 ### Prerequisites
 
-- Node.js 18 or higher
-- npm or pnpm
+- Node.js 18 or higher (BigInt support required)
+- npm, pnpm or yarn
 
 ### Install
 
@@ -301,8 +312,11 @@ const cidr = CIDR.parse('2001:db8::/32');
 console.log(cidr.size()); // 79228162514264337593543950336n
 
 // IPv6 always includes all addresses in hosts()
-const hosts = Array.from(cidr.hosts({ includeEdges: true }));
-console.log(hosts.length); // Very large, use with limit
+// Use the generator form to avoid materializing huge arrays:
+for (const h of cidr.hosts({ includeEdges: true })) {
+  // process host lazily
+  break; // example: stop after first
+}
 ```
 
 ### IP Ranges
@@ -447,6 +461,34 @@ try {
 }
 ```
 
+## Errors & Types
+
+- This library throws a small set of custom errors exported from `src/core/errors.ts`:
+  - `ParseError` — input parsing failures
+  - `InvariantError` — internal invariant violation (logic error)
+  - `OutOfRangeError` — numeric or prefix out-of-range
+  - `VersionMismatchError` — operations attempted with mixed IP versions
+
+- Important: most address/size arithmetic uses `BigInt`. Where counts are small (indexes, array sizes) `number` is used, but IP math and sizes return `bigint`.
+
+## Test & Development (recommended)
+
+Run these commands from the project root:
+
+```bash
+# install dependencies (use npm or pnpm as preferred)
+npm ci
+
+# typecheck
+npm run typecheck
+
+# run tests
+npm test
+
+# build
+npm run build
+```
+
 ## Advanced Examples
 
 ### IPAM (IP Address Management) System
@@ -556,6 +598,8 @@ console.log('All routes:', allRoutes);
 - **IPv6 Edge Inclusion**: IPv6 ranges always include network and broadcast addresses in iterations, as there's no traditional broadcast concept.
 - **RFC 5952 Normalization**: IPv6 addresses are automatically normalized to the canonical compressed form.
 - **Type Safety**: Strict TypeScript with generics ensures version-specific operations are type-checked.
+
+- **split() materializes results**: `CIDR.split(parts)` returns an array of CIDR objects. For large `parts` (especially with IPv6), this can allocate millions of objects and exhaust memory. Prefer iterating the generator returned by `subnets()` for large or unbounded splits.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,13 @@ TypeScript IP Toolkit for IPv4/IPv6 math, CIDR operations, ranges, allocation, a
 [![npm version](https://img.shields.io/npm/v/@h3mantd/ip-kit.svg)](https://www.npmjs.com/package/@h3mantd/ip-kit)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
+## Documentation
+
+- **[API Reference](#api-reference)** - Complete API documentation
+- **[Usage Examples](#usage-examples)** - Practical examples for all features
+- **[IP Calculations Guide](./docs/IP_CALCULATIONS.md)** - Deep dive into the mathematical foundations and BigInt-based calculations
+- **[Contributing Guide](./CONTRIBUTING.md)** - Development setup and contribution guidelines
+
 ## Quick Start
 
 ```typescript
@@ -592,7 +599,7 @@ console.log('All routes:', allRoutes);
 
 ## Caveats and Design Decisions
 
-- **BigInt Usage**: All IP math uses BigInt to avoid floating-point precision issues with large IPv6 addresses.
+- **BigInt Usage**: All IP math uses BigInt to avoid floating-point precision issues with large IPv6 addresses. See our [IP Calculations Guide](./docs/IP_CALCULATIONS.md) for detailed explanations.
 - **Lazy Iterators**: Methods like `hosts()`, `subnets()`, and `ips()` return generators to handle large ranges efficiently without memory issues.
 - **IPv4 /31 and /32 Handling**: For point-to-point links (/31) and single-host (/32), `hosts()` includes all addresses by default. Use `{ includeEdges: false }` to exclude network/broadcast.
 - **IPv6 Edge Inclusion**: IPv6 ranges always include network and broadcast addresses in iterations, as there's no traditional broadcast concept.

--- a/docs/IP_CALCULATIONS.md
+++ b/docs/IP_CALCULATIONS.md
@@ -1,0 +1,467 @@
+# IP Calculations in IP Toolkit
+
+This document provides a comprehensive overview of how IP address calculations are performed in the IP Toolkit library. We'll cover the mathematical foundations, implementation strategies, and design decisions that enable precise and efficient IP operations.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [BigInt Foundation](#bigint-foundation)
+- [IPv4 Calculations](#ipv4-calculations)
+- [IPv6 Calculations](#ipv6-calculations)
+- [CIDR Mathematics](#cidr-mathematics)
+- [Range Operations](#range-operations)
+- [Performance Considerations](#performance-considerations)
+- [Implementation Examples](#implementation-examples)
+
+## Overview
+
+The IP Toolkit uses **BigInt arithmetic** for all IP address calculations to ensure precision and avoid floating-point errors, especially critical for IPv6's 128-bit address space. This approach provides mathematically correct results for operations involving large address spaces.
+
+### Core Principles
+
+1. **All IP addresses are stored as BigInt values**
+2. **Bitwise operations use BigInt masks and shifts**
+3. **No floating-point arithmetic in address calculations**
+4. **Generators for memory-efficient iteration over large ranges**
+
+## BigInt Foundation
+
+### Why BigInt?
+
+```mermaid
+graph TD
+    A[IP Address Input] --> B{Address Type}
+    B -->|IPv4| C[32-bit value]
+    B -->|IPv6| D[128-bit value]
+    C --> E[Convert to BigInt]
+    D --> E
+    E --> F[All calculations in BigInt]
+    F --> G[Precise results]
+    F --> H[No overflow/precision loss]
+```
+
+### Constants and Masks
+
+The library defines core constants in `src/core/bigint.ts`:
+
+```typescript
+// IPv4 constants
+export const BITS4 = 32;
+export const MAX4 = (1n << 32n) - 1n; // 4,294,967,295
+
+// IPv6 constants
+export const BITS6 = 128;
+export const MAX6 = (1n << 128n) - 1n; // 340,282,366,920,938,463,463,374,607,431,768,211,455
+
+// Prefix mask generation
+export function prefixMask(prefix: number, bits: number): bigint {
+  if (prefix === 0) return 0n;
+  if (prefix >= bits) return (1n << BigInt(bits)) - 1n;
+  return ((1n << BigInt(prefix)) - 1n) << BigInt(bits - prefix);
+}
+
+// Host mask (inverse of prefix mask)
+export function hostMask(prefix: number, bits: number): bigint {
+  return ((1n << BigInt(bits)) - 1n) ^ prefixMask(prefix, bits);
+}
+```
+
+### Mathematical Operations
+
+```mermaid
+graph LR
+    A[IP Address BigInt] --> B[Network Calculation]
+    A --> C[Broadcast Calculation]
+    A --> D[Host Range Calculation]
+
+    B --> E["address & prefixMask"]
+    C --> F["network | hostMask"]
+    D --> G["network + 1 to broadcast - 1"]
+
+    E --> H[Network Address]
+    F --> I[Broadcast Address]
+    G --> J[Host Range]
+```
+
+## IPv4 Calculations
+
+### Address Parsing and Conversion
+
+IPv4 addresses are converted to 32-bit BigInt values:
+
+```typescript
+// String to BigInt conversion
+function parseIPv4String(ip: string): bigint {
+  const parts = ip.split('.');
+  if (parts.length !== 4) throw new ParseError('Invalid IPv4 format');
+
+  let result = 0n;
+  for (let i = 0; i < 4; i++) {
+    const octet = Number(parts[i]);
+    if (octet < 0 || octet > 255) throw new ParseError('Invalid octet');
+    result = (result << 8n) | BigInt(octet);
+  }
+  return result;
+}
+
+// BigInt to string conversion
+function formatIPv4(value: bigint): string {
+  const octets: number[] = [];
+  for (let i = 3; i >= 0; i--) {
+    octets.push(Number((value >> BigInt(i * 8)) & 0xffn));
+  }
+  return octets.join('.');
+}
+```
+
+### CIDR Network Calculations
+
+```mermaid
+graph TD
+    A["192.168.1.100/24"] --> B["Parse IP: 192.168.1.100"]
+    A --> C["Parse Prefix: 24"]
+    B --> D["Convert to BigInt: 3232235876n"]
+    C --> E["Generate Prefix Mask: 0xFFFFFF00"]
+    D --> F[Calculate Network]
+    E --> F
+    F --> G["Network = IP & Mask = 3232235776n"]
+    G --> H["Format: 192.168.1.0"]
+
+    G --> I[Calculate Broadcast]
+    E --> J["Generate Host Mask: 0x000000FF"]
+    I --> K["Broadcast = Network | HostMask"]
+    J --> K
+    K --> L["Broadcast = 3232236031n"]
+    L --> M["Format: 192.168.1.255"]
+```
+
+### Host Enumeration
+
+For efficient host iteration, we use generators:
+
+```typescript
+function* hosts(network: bigint, prefix: number, includeEdges: boolean): Generator<bigint> {
+  const hostBits = BITS4 - prefix;
+  const hostCount = 1n << BigInt(hostBits);
+
+  let start = network;
+  let end = network + hostCount - 1n;
+
+  // Handle edge cases for different prefix lengths
+  if (!includeEdges && hostBits > 1) {
+    start += 1n; // Skip network address
+    end -= 1n; // Skip broadcast address
+  }
+
+  for (let host = start; host <= end; host++) {
+    yield host;
+  }
+}
+```
+
+## IPv6 Calculations
+
+### Address Parsing and Normalization
+
+IPv6 parsing is more complex due to compression and various formats:
+
+```mermaid
+graph TD
+    A[IPv6 Input String] --> B{"Contains '::'?"}
+    B -->|Yes| C[Handle Compression]
+    B -->|No| D[Parse All Groups]
+    C --> E["Split on '::'"]
+    E --> F[Parse Left Groups]
+    E --> G[Parse Right Groups]
+    F --> H[Calculate Missing Groups]
+    G --> H
+    H --> I[Reconstruct Full Address]
+    D --> I
+    I --> J[Convert to 128-bit BigInt]
+    J --> K[Apply RFC 5952 Normalization]
+```
+
+### RFC 5952 Normalization
+
+The library implements strict RFC 5952 normalization:
+
+```typescript
+function normalizeIPv6(groups: number[]): string {
+  // 1. Convert to lowercase hex
+  // 2. Remove leading zeros
+  // 3. Find longest run of consecutive zeros
+  // 4. Compress with '::' (leftmost if tied)
+  // 5. Never compress single zero group
+
+  const formatted = groups.map((g) => g.toString(16));
+
+  // Find longest zero run
+  let maxZeroStart = -1;
+  let maxZeroLength = 0;
+  let currentZeroStart = -1;
+  let currentZeroLength = 0;
+
+  for (let i = 0; i < 8; i++) {
+    if (groups[i] === 0) {
+      if (currentZeroStart === -1) {
+        currentZeroStart = i;
+        currentZeroLength = 1;
+      } else {
+        currentZeroLength++;
+      }
+    } else {
+      if (currentZeroLength > maxZeroLength) {
+        maxZeroStart = currentZeroStart;
+        maxZeroLength = currentZeroLength;
+      }
+      currentZeroStart = -1;
+      currentZeroLength = 0;
+    }
+  }
+
+  // Compress if run is 2 or more consecutive zeros
+  if (maxZeroLength >= 2) {
+    const before = formatted.slice(0, maxZeroStart);
+    const after = formatted.slice(maxZeroStart + maxZeroLength);
+    return before.join(':') + '::' + after.join(':');
+  }
+
+  return formatted.join(':');
+}
+```
+
+### IPv6 CIDR Operations
+
+IPv6 CIDR calculations follow the same pattern as IPv4 but with 128-bit arithmetic:
+
+```mermaid
+graph LR
+    A["2001:db8::/32"] --> B["Parse: 2001:db8:0:0:0:0:0:0"]
+    B --> C["Convert to BigInt: 42540766411282592856903984951653826560n"]
+    A --> D["Prefix: 32"]
+    D --> E[Generate 128-bit Prefix Mask]
+    C --> F["Network = IP & Mask"]
+    E --> F
+    F --> G["Size = 2^96 addresses"]
+    G --> H[96-bit host space]
+```
+
+## CIDR Mathematics
+
+### Subnetting Algorithm
+
+Subnetting involves splitting a CIDR block into smaller, equally-sized blocks:
+
+```mermaid
+graph TD
+    A["Parent CIDR: 192.168.1.0/24"] --> B["New Prefix: /26"]
+    B --> C[Calculate Subnet Size]
+    C --> D["2^(32-26) = 64 addresses per subnet"]
+    A --> E[Calculate Number of Subnets]
+    E --> F["2^(26-24) = 4 subnets"]
+
+    F --> G["Subnet 0: 192.168.1.0/26"]
+    F --> H["Subnet 1: 192.168.1.64/26"]
+    F --> I["Subnet 2: 192.168.1.128/26"]
+    F --> J["Subnet 3: 192.168.1.192/26"]
+```
+
+### Implementation
+
+```typescript
+function* subnets(
+  network: bigint,
+  currentPrefix: number,
+  newPrefix: number,
+  bits: number
+): Generator<bigint> {
+  if (newPrefix <= currentPrefix) {
+    throw new Error('New prefix must be longer than current prefix');
+  }
+
+  const subnetBits = newPrefix - currentPrefix;
+  const subnetCount = 1n << BigInt(subnetBits);
+  const subnetSize = 1n << BigInt(bits - newPrefix);
+
+  for (let i = 0n; i < subnetCount; i++) {
+    yield network + i * subnetSize;
+  }
+}
+```
+
+### Block Splitting
+
+For power-of-two splits, we use efficient bit shifting:
+
+```mermaid
+graph LR
+    A["Split /24 into 4 parts"] --> B["Calculate: log2(4) = 2 bits"]
+    B --> C["New prefix: 24 + 2 = /26"]
+    C --> D["Generate 4 subnets with /26"]
+```
+
+## Range Operations
+
+### Range to CIDR Conversion
+
+Converting IP ranges to minimal CIDR sets requires finding the largest aligned blocks:
+
+```mermaid
+graph TD
+    A["IP Range: 192.168.1.10 - 192.168.1.20"] --> B["Start: 192.168.1.10"]
+    A --> C["End: 192.168.1.20"]
+    B --> D[Find Max Aligned Block from Start]
+    D --> E["Block 1: 192.168.1.10/31 covers 10-11"]
+    E --> F["Remaining: 192.168.1.12 - 192.168.1.20"]
+    F --> G["Block 2: 192.168.1.12/30 covers 12-15"]
+    G --> H["Remaining: 192.168.1.16 - 192.168.1.20"]
+    H --> I["Block 3: 192.168.1.16/30 covers 16-19"]
+    I --> J["Remaining: 192.168.1.20/32"]
+    J --> K["Final: 4 CIDR blocks total"]
+```
+
+### Algorithm
+
+```typescript
+function rangeToCIDRs(start: bigint, end: bigint, bits: number): bigint[] {
+  const cidrs: bigint[] = [];
+  let current = start;
+
+  while (current <= end) {
+    // Find the largest block that:
+    // 1. Starts at current address
+    // 2. Is properly aligned
+    // 3. Doesn't exceed the end address
+
+    const maxBlock = maxAlignedBlock(current, end, bits);
+    cidrs.push(maxBlock);
+
+    const blockSize = 1n << BigInt(bits - maxBlock.prefix);
+    current += blockSize;
+  }
+
+  return cidrs;
+}
+
+function maxAlignedBlock(
+  start: bigint,
+  end: bigint,
+  bits: number
+): { network: bigint; prefix: number } {
+  let prefix = bits;
+
+  // Find the longest prefix where:
+  // 1. start is aligned to the block boundary
+  // 2. the entire block fits within [start, end]
+  while (prefix > 0) {
+    const blockSize = 1n << BigInt(bits - prefix);
+    const network = start & prefixMask(prefix, bits);
+
+    if (network === start && start + blockSize - 1n <= end) {
+      return { network, prefix };
+    }
+    prefix--;
+  }
+
+  return { network: start, prefix: bits };
+}
+```
+
+### Set Operations
+
+Range set operations (union, intersect, subtract) use interval arithmetic:
+
+```mermaid
+graph LR
+    A[RangeSet A] --> D[Normalize Ranges]
+    B[RangeSet B] --> D
+    D --> E[Sort by Start Address]
+    E --> F[Merge Overlapping]
+    F --> G{Operation Type}
+    G -->|Union| H[Combine All Ranges]
+    G -->|Intersect| I[Find Overlaps Only]
+    G -->|Subtract| J[Remove B from A]
+    H --> K[Normalized Result]
+    I --> K
+    J --> K
+```
+
+## Performance Considerations
+
+### Memory Efficiency
+
+1. **Generators for Large Ranges**: Instead of materializing millions of IP addresses, we use generators:
+
+```typescript
+// Bad: Creates array of 16M+ addresses
+const hosts = Array.from(cidr.hosts());
+
+// Good: Lazy evaluation
+for (const host of cidr.hosts()) {
+  if (someCondition) break; // Can exit early
+}
+```
+
+2. **BigInt Optimization**: While BigInt operations are slower than regular numbers, they're necessary for correctness with large IPv6 ranges.
+
+### Algorithmic Complexity
+
+```mermaid
+graph TD
+    A[Operation Types] --> B["O(1) Operations"]
+    A --> C["O(log n) Operations"]
+    A --> D["O(n) Operations"]
+
+    B --> E[IP Parsing]
+    B --> F[CIDR Network/Broadcast]
+    B --> G[Containment Check]
+
+    C --> H[Trie Lookup]
+    C --> I[Range Binary Search]
+
+    D --> J[Host Enumeration]
+    D --> K[Range Set Operations]
+    D --> L[CIDR Set Conversion]
+```
+
+### Edge Case Handling
+
+Special attention is paid to boundary conditions:
+
+1. **IPv4 /31 and /32 Networks**: Point-to-point and host routes
+2. **IPv6 /127 and /128 Networks**: Similar handling for IPv6
+3. **Maximum Range Sizes**: IPv6 /0 contains 2^128 addresses
+4. **Alignment Requirements**: CIDR blocks must be power-of-two aligned
+
+## Implementation Examples
+
+### Example 1: CIDR Network Calculation
+
+```typescript
+// Input: 192.168.1.100/24
+const ip = parseIPv4String('192.168.1.100'); // 3232235876n
+const prefix = 24;
+const prefixMask = 0xffffff00n; // /24 mask
+const network = ip & prefixMask; // 3232235776n
+const networkStr = formatIPv4(network); // "192.168.1.0"
+```
+
+### Example 2: IPv6 Compression
+
+```typescript
+// Input: "2001:0db8:0000:0000:0000:0000:0000:0001"
+const groups = [0x2001, 0x0db8, 0x0000, 0x0000, 0x0000, 0x0000, 0x0000, 0x0001];
+// Find longest zero run: index 2-6 (length 5)
+// Result: "2001:db8::1"
+```
+
+### Example 3: Range to CIDR Conversion
+
+```typescript
+// Input: 192.168.1.10 - 192.168.1.13
+// Start: 3232235786n, End: 3232235789n
+// Result: [192.168.1.10/31, 192.168.1.12/30]
+// Covers: [10,11] and [12,13,14,15] but limited to [12,13]
+```
+
+This mathematical foundation ensures that all IP operations in the toolkit are precise, efficient, and handle edge cases correctly, providing a reliable base for network management and analysis tools.

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,10 @@
 
 This directory contains examples demonstrating the various features of the IP Toolkit.
 
+## Understanding the Math
+
+For detailed explanations of how IP calculations work under the hood, including BigInt usage and CIDR mathematics, see our **[IP Calculations Guide](../docs/IP_CALCULATIONS.md)**.
+
 ## Running Examples
 
 ### Prerequisites
@@ -39,19 +43,30 @@ npx tsx examples/basic.ts
 ## Example Categories
 
 ### Basic Operations
+
 - IP address parsing and formatting
 - CIDR network calculations
 - IP range operations
 
 ### Advanced Features
+
 - Range set operations (union, intersect, subtract)
 - IP address allocation and management
 - Longest prefix matching with radix trie
 
 ### Real-world Use Cases
+
 - IPAM (IP Address Management) system
 - Routing table implementation
 - Network planning and analysis
+
+### Mathematical Foundations
+
+- See **[IP Calculations Guide](../docs/IP_CALCULATIONS.md)** for detailed explanations of:
+  - BigInt-based arithmetic
+  - CIDR mathematics and subnetting algorithms
+  - Range-to-CIDR conversion
+  - IPv6 normalization (RFC 5952)
 
 ## Example Files
 

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -25,6 +25,14 @@ console.log(`Broadcast: ${cidr.broadcast().toString()}`);
 console.log(`Size: ${cidr.size()} addresses`);
 console.log(`Contains 192.168.1.50: ${cidr.contains(IPv4.parse('192.168.1.50'))}\n`);
 
+// Subnetting (generator example)
+console.log('4a. Subnetting /24 into /26 subnets (generator):');
+let idx = 0;
+for (const s of cidr.subnets(26)) {
+	console.log(`Subnet ${++idx}: ${s.toString()}`);
+}
+console.log();
+
 // Range operations
 console.log('3. IP Range Operations:');
 const range = IPRange.parse('192.168.1.10 - 192.168.1.20');
@@ -54,6 +62,11 @@ console.log(`Allocated IP: ${allocatedIP?.toString()}`);
 console.log(`Available IPs: ${allocator.availableCount()}`);
 console.log(`Utilization: ${(allocator.utilization() * 100).toFixed(1)}%`);
 console.log(`Free /25 blocks: ${freeBlocks.length}\n`);
+
+// Demonstrate first/last host semantics for the parent CIDR
+console.log('First host (default):', parent.firstHost().toString());
+console.log('Last host (default):', parent.lastHost().toString());
+console.log('First host (includeEdges=true):', parent.firstHost({ includeEdges: true }).toString());
 
 // Longest prefix matching
 console.log('6. Longest Prefix Matching:');

--- a/examples/basic.js
+++ b/examples/basic.js
@@ -3,6 +3,9 @@
 /**
  * IP Toolkit Examples
  * Run with: node examples/basic.js
+ *
+ * For detailed explanations of the underlying mathematics and BigInt calculations,
+ * see: ../docs/IP_CALCULATIONS.md
  */
 
 import { IPv4, IPv6, CIDR, IPRange, RangeSet, Allocator, RadixTrie } from '../dist/index.js';
@@ -29,7 +32,7 @@ console.log(`Contains 192.168.1.50: ${cidr.contains(IPv4.parse('192.168.1.50'))}
 console.log('4a. Subnetting /24 into /26 subnets (generator):');
 let idx = 0;
 for (const s of cidr.subnets(26)) {
-	console.log(`Subnet ${++idx}: ${s.toString()}`);
+  console.log(`Subnet ${++idx}: ${s.toString()}`);
 }
 console.log();
 
@@ -39,7 +42,12 @@ const range = IPRange.parse('192.168.1.10 - 192.168.1.20');
 console.log(`Range: ${range.toString()}`);
 console.log(`Size: ${range.size()} addresses`);
 console.log(`Contains 192.168.1.15: ${range.contains(IPv4.parse('192.168.1.15'))}`);
-console.log(`Minimal CIDRs: ${range.toCIDRs().map(c => c.toString()).join(', ')}\n`);
+console.log(
+  `Minimal CIDRs: ${range
+    .toCIDRs()
+    .map((c) => c.toString())
+    .join(', ')}\n`
+);
 
 // Range set operations
 console.log('4. Range Set Operations:');
@@ -49,7 +57,12 @@ const union = set1.union(set2);
 console.log(`Set 1 size: ${set1.size()}`);
 console.log(`Set 2 size: ${set2.size()}`);
 console.log(`Union size: ${union.size()}`);
-console.log(`Union as CIDRs: ${union.toCIDRs().map(c => c.toString()).join(', ')}\n`);
+console.log(
+  `Union as CIDRs: ${union
+    .toCIDRs()
+    .map((c) => c.toString())
+    .join(', ')}\n`
+);
 
 // IP allocation
 console.log('5. IP Address Allocation:');

--- a/examples/basic.ts
+++ b/examples/basic.ts
@@ -6,7 +6,7 @@
  * Run with: pnpm tsx examples/basic.ts
  */
 
-import { ip, cidr, IPv4, CIDR, IPRange } from "../src/index";
+import { ip, cidr, IPv4, CIDR, IPRange, Allocator } from "../src/index";
 
 console.log("=== IP Toolkit Basic Examples ===\n");
 
@@ -39,12 +39,13 @@ for (const host of network.hosts()) {
 console.log("...\n");
 
 // 4. Subnetting
-console.log("4. Subnetting /24 into /26 subnets:");
+console.log("4. Subnetting /24 into /26 subnets (generator):");
 const ipv4Network = network as CIDR<4>;
-const subnets = Array.from(ipv4Network.subnets(26));
-subnets.forEach((subnet, i) => {
-  console.log(`Subnet ${i + 1}: ${subnet.toString()}`);
-});
+let idx = 0;
+for (const subnet of ipv4Network.subnets(26)) {
+  console.log(`Subnet ${++idx}: ${subnet.toString()}`);
+}
+// Avoid Array.from(...) on very large networks — prefer the generator above.
 console.log();
 
 // 5. IP Ranges
@@ -66,6 +67,25 @@ const v6cidr = cidr("2001:db8::/32");
 console.log(`IPv6 CIDR: ${v6cidr.toString()}`);
 console.log(`Size: ${v6cidr.size()} addresses`);
 console.log(`Network: ${v6cidr.network().toString()}\n`);
+console.log();
+
+// Demonstrate firstHost()/lastHost() semantics (IPv4)
+console.log("First/Last host semantics for IPv4 /24:");
+console.log(`First host (default): ${ipv4Network.firstHost().toString()}`);
+console.log(`Last host (default): ${ipv4Network.lastHost().toString()}`);
+console.log(
+  `First host (includeEdges=true): ${ipv4Network.firstHost({ includeEdges: true }).toString()}`,
+);
+console.log();
+
+// 8. Allocator demonstration
+console.log("8. Allocator demonstration:");
+const allocator = new Allocator(ipv4Network);
+const allocated = allocator.allocateNext();
+console.log(`Allocated IP: ${allocated?.toString()}`);
+console.log(`Available IPs: ${allocator.availableCount()}`);
+console.log(`Utilization: ${(allocator.utilization() * 100).toFixed(1)}%`);
+console.log();
 
 // 7. Error Handling
 console.log("7. Error Handling:");

--- a/src/core/bigint.ts
+++ b/src/core/bigint.ts
@@ -1,6 +1,7 @@
 /**
  * BigInt utilities for IP address math.
  */
+import { OutOfRangeError } from './errors';
 
 export const BITS4 = 32n;
 export const BITS6 = 128n;
@@ -11,14 +12,27 @@ export const MAX6 = (1n << BITS6) - 1n;
  * Returns the network mask for a given prefix length.
  */
 export function prefixMask(prefix: number, bits: 32 | 128): bigint {
-  return ((1n << BigInt(prefix)) - 1n) << BigInt(bits - prefix);
+  if (bits !== 32 && bits !== 128) {
+    throw new OutOfRangeError(`bits must be 32 or 128, got ${bits}`);
+  }
+  const max = bits === 32 ? MAX4 : MAX6;
+  if (prefix < 0 || prefix > bits) {
+    throw new OutOfRangeError(`prefix must be between 0 and ${bits}, got ${prefix}`);
+  }
+  if (prefix === 0) return 0n;
+  if (prefix === bits) return max;
+  return (((1n << BigInt(prefix)) - 1n) << BigInt(bits - prefix)) & max;
 }
 
 /**
  * Returns the host mask for a given prefix length.
  */
 export function hostMask(prefix: number, bits: 32 | 128): bigint {
-  return ~prefixMask(prefix, bits) & ((1n << BigInt(bits)) - 1n);
+  if (bits !== 32 && bits !== 128) {
+    throw new OutOfRangeError(`bits must be 32 or 128, got ${bits}`);
+  }
+  const mask = bits === 32 ? MAX4 : MAX6;
+  return (~prefixMask(prefix, bits)) & mask;
 }
 
 /**
@@ -39,6 +53,12 @@ export function broadcastOf(ip: bigint, prefix: number, bits: 32 | 128): bigint 
  * Checks if the bit at the specified position from MSB is set.
  */
 export function bitAtMSB(value: bigint, bit: number, bits: 32 | 128): boolean {
+  if (bits !== 32 && bits !== 128) {
+    throw new OutOfRangeError(`bits must be 32 or 128, got ${bits}`);
+  }
+  if (bit < 0 || bit >= bits) {
+    throw new OutOfRangeError(`bit index out of range 0..${bits - 1}: ${bit}`);
+  }
   return (value & (1n << BigInt(bits - 1 - bit))) !== 0n;
 }
 
@@ -50,21 +70,33 @@ export function maxAlignedBlock(
   end: bigint,
   bits: 32 | 128
 ): { prefix: number; block: bigint } | null {
+  if (bits !== 32 && bits !== 128) {
+    throw new OutOfRangeError(`bits must be 32 or 128, got ${bits}`);
+  }
+  if (end < start) return null;
+
   const size = end - start + 1n;
   if (size <= 0n) return null;
 
-  // Find largest power of 2 <= size
-  let prefixLen = 0;
+  // Find largest exponent p such that 2^p <= size
+  let maxExp = 0n;
   let blockSize = 1n;
   while (blockSize * 2n <= size) {
     blockSize *= 2n;
-    prefixLen++;
+    maxExp++;
   }
 
-  // Check if start is aligned to blockSize
-  const alignedStart = (start / blockSize) * blockSize;
-  if (alignedStart >= start && alignedStart + blockSize - 1n <= end) {
-    return { prefix: bits - prefixLen, block: alignedStart };
+  // Try from largest block down to smallest. For each block size, align up from `start`
+  // to the next boundary and check if the block fits inside [start, end].
+  for (let p = maxExp; p >= 0n; p--) {
+    const bs = 1n << p; // block size
+    // align up: first address >= start that is multiple of bs
+    const firstAligned = ((start + bs - 1n) / bs) * bs;
+    if (firstAligned + bs - 1n <= end) {
+      const prefix = bits - Number(p);
+      return { prefix, block: firstAligned };
+    }
+    if (p === 0n) break;
   }
 
   return null;

--- a/src/core/bigint.ts
+++ b/src/core/bigint.ts
@@ -32,7 +32,7 @@ export function hostMask(prefix: number, bits: 32 | 128): bigint {
     throw new OutOfRangeError(`bits must be 32 or 128, got ${bits}`);
   }
   const mask = bits === 32 ? MAX4 : MAX6;
-  return (~prefixMask(prefix, bits)) & mask;
+  return ~prefixMask(prefix, bits) & mask;
 }
 
 /**

--- a/src/core/ptr.ts
+++ b/src/core/ptr.ts
@@ -48,16 +48,18 @@ export function ptrZonesForCIDR(ip: bigint, prefix: number, bits: 32 | 128): str
     return [ptrV4(network)];
   } else {
     // IPv6: nibble-aligned zones. Round prefix down to a multiple of 4
-  const nibblePrefix = Math.floor(prefix / 4) * 4;
-  const zonePrefix = Math.min(nibblePrefix, 124); // up to /124 usually
+    const nibblePrefix = Math.floor(prefix / 4) * 4;
+    const zonePrefix = Math.min(nibblePrefix, 124); // up to /124 usually
     // Build nibbles for the network and truncate to zonePrefix nibbles
     const nibbles: string[] = [];
     for (let i = 0; i < 32; i++) {
       const nib = Number((ip >> BigInt((31 - i) * 4)) & 0xfn);
       nibbles.push(nib.toString(16));
     }
-  const usedNibbles = Math.floor(zonePrefix / 4); // number of nibbles covered by zonePrefix
-  const zone = (usedNibbles === 0 ? '' : nibbles.slice(0, usedNibbles).reverse().join('.') + '.') + 'ip6.arpa';
+    const usedNibbles = Math.floor(zonePrefix / 4); // number of nibbles covered by zonePrefix
+    const zone =
+      (usedNibbles === 0 ? '' : nibbles.slice(0, usedNibbles).reverse().join('.') + '.') +
+      'ip6.arpa';
     return [zone];
   }
 }

--- a/src/domain/allocator.ts
+++ b/src/domain/allocator.ts
@@ -92,8 +92,8 @@ export class Allocator<V extends IPVersion = IPVersion> {
       return false;
     }
 
-  const range = cidr.toRange();
-  const newTakenRanges = [...this._taken.toArray(), range];
+    const range = cidr.toRange();
+    const newTakenRanges = [...this._taken.toArray(), range];
     this._taken = RangeSet.fromRanges(newTakenRanges);
     return true;
   }
@@ -169,7 +169,9 @@ export class Allocator<V extends IPVersion = IPVersion> {
       if (end < fromVal) continue;
       const candidate = start >= fromVal ? start : fromVal + 1n;
       if (candidate <= end) {
-        return this.version === 4 ? (IPv4.fromBigInt(candidate) as IP<V>) : (IPv6.fromBigInt(candidate) as IP<V>);
+        return this.version === 4
+          ? (IPv4.fromBigInt(candidate) as IP<V>)
+          : (IPv6.fromBigInt(candidate) as IP<V>);
       }
     }
 
@@ -193,7 +195,7 @@ export class Allocator<V extends IPVersion = IPVersion> {
   private getFreeRanges(): IPRange<V>[] {
     const parentRange = this.parent.toRange();
     const parentRangeSet = RangeSet.fromRanges([parentRange]);
-  const freeSet = parentRangeSet.subtract(this._taken);
-  return freeSet.toArray();
+    const freeSet = parentRangeSet.subtract(this._taken);
+    return freeSet.toArray();
   }
 }

--- a/src/domain/allocator.ts
+++ b/src/domain/allocator.ts
@@ -19,7 +19,7 @@ export class Allocator<V extends IPVersion = IPVersion> {
     this.version = parent.version;
 
     // Validate that all taken ranges are within the parent
-    for (const range of this._taken['ranges']) {
+    for (const range of this._taken.toArray()) {
       if (!parent.contains(range.start) || !parent.contains(range.end)) {
         throw new ParseError('Taken ranges must be within the parent CIDR');
       }
@@ -68,8 +68,13 @@ export class Allocator<V extends IPVersion = IPVersion> {
       return false;
     }
 
-    const range = (IPRange as any).from(ip, ip) as IPRange<V>;
-    const newTakenRanges = [...this._taken['ranges'], range];
+    let range: IPRange<V>;
+    if (this.version === 4) {
+      range = IPRange.from(ip as IPv4, ip as IPv4) as IPRange<V>;
+    } else {
+      range = IPRange.from(ip as IPv6, ip as IPv6) as IPRange<V>;
+    }
+    const newTakenRanges = [...this._taken.toArray(), range];
     this._taken = RangeSet.fromRanges(newTakenRanges);
     return true;
   }
@@ -87,8 +92,8 @@ export class Allocator<V extends IPVersion = IPVersion> {
       return false;
     }
 
-    const range = cidr.toRange();
-    const newTakenRanges = [...this._taken['ranges'], range];
+  const range = cidr.toRange();
+  const newTakenRanges = [...this._taken.toArray(), range];
     this._taken = RangeSet.fromRanges(newTakenRanges);
     return true;
   }
@@ -131,20 +136,40 @@ export class Allocator<V extends IPVersion = IPVersion> {
    */
   utilization(): number {
     const total = this.parent.size();
-    const taken = this._taken.size();
-    return Number(taken) / Number(total);
+    let taken = this._taken.size();
+
+    // If total is small enough, do a direct conversion.
+    const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+    if (total <= maxSafe) {
+      return Number(taken) / Number(total);
+    }
+
+    // Scale both down by right-shifting until total fits into Number.MAX_SAFE_INTEGER.
+    // This preserves the ratio approximately and avoids converting huge BigInts to Number.
+    let scaledTotal = total;
+    let scaledTaken = taken;
+    while (scaledTotal > maxSafe) {
+      scaledTotal >>= 1n;
+      scaledTaken >>= 1n;
+    }
+
+    if (scaledTotal === 0n) return 0;
+    return Number(scaledTaken) / Number(scaledTotal);
   }
 
   // Private helper methods
 
   private findNextAvailable(from: IP<V>): IP<V> | null {
-    const fromBigInt = from.toBigInt();
-    const parentEnd = this.parent.toRange().end.toBigInt();
-
-    for (let current = fromBigInt + 1n; current <= parentEnd; current++) {
-      const ip = this.version === 4 ? IPv4.fromBigInt(current) : IPv6.fromBigInt(current);
-      if (!this._taken.contains(ip as IP<V>)) {
-        return ip as IP<V>;
+    // Efficient approach: iterate free ranges and pick first address after `from`.
+    const fromVal = from.toBigInt();
+    const freeRanges = this.getFreeRanges();
+    for (const r of freeRanges) {
+      const start = r.start.toBigInt();
+      const end = r.end.toBigInt();
+      if (end < fromVal) continue;
+      const candidate = start >= fromVal ? start : fromVal + 1n;
+      if (candidate <= end) {
+        return this.version === 4 ? (IPv4.fromBigInt(candidate) as IP<V>) : (IPv6.fromBigInt(candidate) as IP<V>);
       }
     }
 
@@ -157,7 +182,7 @@ export class Allocator<V extends IPVersion = IPVersion> {
   }
 
   private overlapsTaken(range: IPRange<V>): boolean {
-    for (const takenRange of this._taken['ranges']) {
+    for (const takenRange of this._taken.toArray()) {
       if (takenRange.overlaps(range)) {
         return true;
       }
@@ -168,7 +193,7 @@ export class Allocator<V extends IPVersion = IPVersion> {
   private getFreeRanges(): IPRange<V>[] {
     const parentRange = this.parent.toRange();
     const parentRangeSet = RangeSet.fromRanges([parentRange]);
-    const freeSet = parentRangeSet.subtract(this._taken);
-    return freeSet['ranges'];
+  const freeSet = parentRangeSet.subtract(this._taken);
+  return freeSet.toArray();
   }
 }

--- a/src/domain/allocator.ts
+++ b/src/domain/allocator.ts
@@ -34,7 +34,7 @@ export class Allocator<V extends IPVersion = IPVersion> {
    * Find the next available IP address starting from the given IP.
    */
   nextAvailable(from?: IP<V>): IP<V> | null {
-    const startIp = from || this.parent.firstHost();
+    const startIp = from || this.parent.firstHost({ includeEdges: false });
 
     // If the start IP is already taken, find the next one
     if (this._taken.contains(startIp as IP<V>)) {

--- a/src/domain/cidr.ts
+++ b/src/domain/cidr.ts
@@ -90,7 +90,7 @@ export class CIDR<V extends IPVersion = IPVersion> {
   }
 
   firstHost(opts?: { includeEdges?: boolean }): typeof this.ip {
-    const includeEdges = opts?.includeEdges ?? this.prefix >= (this.version === 4 ? 31 : 127);
+    const includeEdges = opts?.includeEdges ?? (this.version === 6 || this.prefix >= 31);
     if (!includeEdges && this.prefix >= (this.version === 4 ? 31 : 127)) {
       throw new InvariantError('No hosts available');
     }

--- a/src/domain/rangeset.ts
+++ b/src/domain/rangeset.ts
@@ -26,7 +26,7 @@ export class RangeSet<V extends IPVersion = IPVersion> {
    * Create a RangeSet from CIDR blocks.
    */
   static fromCIDRs<V extends IPVersion>(cidrs: Array<CIDR<V> | string>): RangeSet<V> {
-  if (!cidrs || cidrs.length === 0) return new RangeSet([]);
+    if (!cidrs || cidrs.length === 0) return new RangeSet([]);
     const ranges: IPRange<V>[] = [];
     let version: V | undefined;
     for (const cidr of cidrs) {

--- a/src/domain/trie.ts
+++ b/src/domain/trie.ts
@@ -49,9 +49,9 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
       }
       node = node.children.get(bit)!;
     }
-  node.value = value;
-  node.storedPrefix = cidr.prefix;
-  node.network = cidr.network().toBigInt();
+    node.value = value;
+    node.storedPrefix = cidr.prefix;
+    node.network = cidr.network().toBigInt();
     return this;
   }
 
@@ -79,9 +79,9 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
     }
 
     // Remove the value
-  delete node.value;
-  delete node.storedPrefix;
-  delete node.network;
+    delete node.value;
+    delete node.storedPrefix;
+    delete node.network;
 
     // Clean up empty nodes
     for (let i = path.length - 1; i >= 0; i--) {
@@ -166,7 +166,8 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
   private reconstructCIDR(ip: IP<V>, node: TrieNode<T>): CIDR<V> {
     const prefixLength = node.storedPrefix!;
     if (node.network !== undefined) {
-      const networkIP = ip.version === 4 ? IPv4.fromBigInt(node.network) : IPv6.fromBigInt(node.network);
+      const networkIP =
+        ip.version === 4 ? IPv4.fromBigInt(node.network) : IPv6.fromBigInt(node.network);
       if (this.version === 4) {
         return CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>;
       } else {
@@ -178,7 +179,8 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
     const bits = ip.version === 4 ? 32 : 128;
     const mask = (1n << BigInt(bits - prefixLength)) - 1n;
     const networkValue = ip.toBigInt() & ~mask;
-    const networkIP = ip.version === 4 ? IPv4.fromBigInt(networkValue) : IPv6.fromBigInt(networkValue);
+    const networkIP =
+      ip.version === 4 ? IPv4.fromBigInt(networkValue) : IPv6.fromBigInt(networkValue);
     if (ip.version === 4) {
       return CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>;
     } else {
@@ -195,14 +197,16 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
     if (node.value !== undefined) {
       const prefixLength = node.storedPrefix!;
       if (node.network !== undefined) {
-        const networkIP = this.version === 4 ? IPv4.fromBigInt(node.network) : IPv6.fromBigInt(node.network);
+        const networkIP =
+          this.version === 4 ? IPv4.fromBigInt(node.network) : IPv6.fromBigInt(node.network);
         if (this.version === 4) {
           result.push(CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>);
         } else {
           result.push(CIDR.from(networkIP as IPv6, prefixLength) as CIDR<V>);
         }
       } else {
-        const networkIP = this.version === 4 ? IPv4.fromBigInt(currentValue) : IPv6.fromBigInt(currentValue);
+        const networkIP =
+          this.version === 4 ? IPv4.fromBigInt(currentValue) : IPv6.fromBigInt(currentValue);
         if (this.version === 4) {
           result.push(CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>);
         } else {

--- a/src/domain/trie.ts
+++ b/src/domain/trie.ts
@@ -5,12 +5,14 @@
 
 import { IP, IPv4, IPv6, IPVersion } from './ip';
 import { CIDR } from './cidr';
+import { VersionMismatchError } from '../core/errors';
 
 interface TrieNode<T> {
   children: Map<number, TrieNode<T>>;
   value?: T;
   prefixLength: number;
   storedPrefix?: number; // Store the actual prefix length for this value
+  network?: bigint; // store network address as bigint when a value is assigned
 }
 
 export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
@@ -30,7 +32,7 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
    */
   insert(cidr: CIDR<V>, value?: T): this {
     if (cidr.version !== this.version) {
-      throw new Error('CIDR version must match trie version');
+      throw new VersionMismatchError('CIDR version must match trie version');
     }
 
     let node = this.root;
@@ -47,9 +49,9 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
       }
       node = node.children.get(bit)!;
     }
-
-    node.value = value;
-    node.storedPrefix = cidr.prefix;
+  node.value = value;
+  node.storedPrefix = cidr.prefix;
+  node.network = cidr.network().toBigInt();
     return this;
   }
 
@@ -58,7 +60,7 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
    */
   remove(cidr: CIDR<V>): this {
     if (cidr.version !== this.version) {
-      throw new Error('CIDR version must match trie version');
+      throw new VersionMismatchError('CIDR version must match trie version');
     }
 
     const path: TrieNode<T>[] = [];
@@ -77,7 +79,9 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
     }
 
     // Remove the value
-    delete node.value;
+  delete node.value;
+  delete node.storedPrefix;
+  delete node.network;
 
     // Clean up empty nodes
     for (let i = path.length - 1; i >= 0; i--) {
@@ -100,17 +104,17 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
    */
   longestMatch(ip: IP<V>): { cidr: CIDR<V>; value?: T } | null {
     if (ip.version !== this.version) {
-      throw new Error('IP version must match trie version');
+      throw new VersionMismatchError('IP version must match trie version');
     }
 
     let node = this.root;
-    let bestMatch: { node: TrieNode<T>; prefixLength: number } | null = null;
+    let bestNode: TrieNode<T> | null = null;
     const bits = ip.version === 4 ? 32 : 128;
     const ipValue = ip.toBigInt();
 
     for (let bitPos = 0; bitPos < bits; bitPos++) {
       if (node.value !== undefined) {
-        bestMatch = { node, prefixLength: bitPos };
+        bestNode = node;
       }
 
       const bit = Number((ipValue >> BigInt(bits - 1 - bitPos)) & 1n);
@@ -122,18 +126,15 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
 
     // Check the final node
     if (node.value !== undefined) {
-      bestMatch = { node, prefixLength: bits };
+      bestNode = node;
     }
 
-    if (!bestMatch) {
-      return null;
-    }
+    if (!bestNode) return null;
 
-    // Reconstruct the CIDR from the path
-    const cidr = this.reconstructCIDR(ip, bestMatch.node);
+    const cidr = this.reconstructCIDR(ip, bestNode);
     return {
       cidr,
-      value: bestMatch.node.value,
+      value: bestNode.value,
     };
   }
 
@@ -164,14 +165,25 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
 
   private reconstructCIDR(ip: IP<V>, node: TrieNode<T>): CIDR<V> {
     const prefixLength = node.storedPrefix!;
+    if (node.network !== undefined) {
+      const networkIP = ip.version === 4 ? IPv4.fromBigInt(node.network) : IPv6.fromBigInt(node.network);
+      if (this.version === 4) {
+        return CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>;
+      } else {
+        return CIDR.from(networkIP as IPv6, prefixLength) as CIDR<V>;
+      }
+    }
+
+    // Fallback: reconstruct using the searched IP (legacy behaviour)
     const bits = ip.version === 4 ? 32 : 128;
     const mask = (1n << BigInt(bits - prefixLength)) - 1n;
     const networkValue = ip.toBigInt() & ~mask;
-
-    const networkIP =
-      ip.version === 4 ? IPv4.fromBigInt(networkValue) : IPv6.fromBigInt(networkValue);
-
-    return (CIDR as any).from(networkIP, prefixLength) as CIDR<V>;
+    const networkIP = ip.version === 4 ? IPv4.fromBigInt(networkValue) : IPv6.fromBigInt(networkValue);
+    if (ip.version === 4) {
+      return CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>;
+    } else {
+      return CIDR.from(networkIP as IPv6, prefixLength) as CIDR<V>;
+    }
   }
 
   private collectCIDRs(
@@ -181,10 +193,22 @@ export class RadixTrie<V extends IPVersion = IPVersion, T = unknown> {
     result: CIDR<V>[]
   ): void {
     if (node.value !== undefined) {
-      const networkIP =
-        this.version === 4 ? IPv4.fromBigInt(currentValue) : IPv6.fromBigInt(currentValue);
       const prefixLength = node.storedPrefix!;
-      result.push((CIDR as any).from(networkIP, prefixLength) as CIDR<V>);
+      if (node.network !== undefined) {
+        const networkIP = this.version === 4 ? IPv4.fromBigInt(node.network) : IPv6.fromBigInt(node.network);
+        if (this.version === 4) {
+          result.push(CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>);
+        } else {
+          result.push(CIDR.from(networkIP as IPv6, prefixLength) as CIDR<V>);
+        }
+      } else {
+        const networkIP = this.version === 4 ? IPv4.fromBigInt(currentValue) : IPv6.fromBigInt(currentValue);
+        if (this.version === 4) {
+          result.push(CIDR.from(networkIP as IPv4, prefixLength) as CIDR<V>);
+        } else {
+          result.push(CIDR.from(networkIP as IPv6, prefixLength) as CIDR<V>);
+        }
+      }
     }
 
     const bits = this.version === 4 ? 32 : 128;

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,11 +16,30 @@ export function ip(input: string | number | bigint | Uint8Array): IPv4 | IPv6 {
     if (IP.isIPv4(input)) return IPv4.parse(input);
     if (IP.isIPv6(input)) return IPv6.parse(input);
   }
-  // For other types, try IPv4 first
+  // For other types, handle by runtime type
+  if (typeof input === 'number') {
+    return IPv4.parse(input);
+  }
+  if (typeof input === 'bigint') {
+    try {
+      return IPv4.parse(input);
+    } catch {
+      return IPv6.parse(input);
+    }
+  }
+  if (input instanceof Uint8Array) {
+    // try IPv4 bytes first
+    try {
+      return IPv4.parse(input);
+    } catch {
+      return IPv6.parse(input);
+    }
+  }
+  // Fallback: attempt IPv4 then IPv6
   try {
-    return IPv4.parse(input as any);
+    return IPv4.parse(input as unknown as string | number | bigint | Uint8Array);
   } catch {
-    return IPv6.parse(input as any);
+    return IPv6.parse(input as unknown as string | bigint | Uint8Array);
   }
 }
 

--- a/tests/core/bigint.test.ts
+++ b/tests/core/bigint.test.ts
@@ -9,6 +9,7 @@ import {
   networkOf,
   broadcastOf,
   bitAtMSB,
+  maxAlignedBlock,
 } from '../../src/core/bigint';
 
 describe('bigint utils', () => {
@@ -41,5 +42,28 @@ describe('bigint utils', () => {
   it('bitAtMSB', () => {
     expect(bitAtMSB(0x80000000n, 0, 32)).toBe(true);
     expect(bitAtMSB(0x40000000n, 0, 32)).toBe(false);
+  });
+
+  it('maxAlignedBlock - aligned start', () => {
+    // range 0..255 should yield /24 at 0
+    const res = maxAlignedBlock(0n, 255n, 32);
+    expect(res).not.toBeNull();
+  // /24 == prefix 24 for a 256-address block
+  expect(res!.prefix).toBe(24);
+    expect(res!.block).toBe(0n);
+  });
+
+  it('maxAlignedBlock - unaligned start but larger block fits later', () => {
+    // start 5, end 20 -> largest aligned block of size 8 is at 8..15 => prefix 29 (32-3)
+    const res = maxAlignedBlock(5n, 20n, 32);
+    expect(res).not.toBeNull();
+    expect(res!.block).toBe(8n);
+  });
+
+  it('maxAlignedBlock - single address', () => {
+    const res = maxAlignedBlock(1000n, 1000n, 32);
+    expect(res).not.toBeNull();
+    expect(res!.prefix).toBe(32);
+    expect(res!.block).toBe(1000n);
   });
 });

--- a/tests/core/normalize.test.ts
+++ b/tests/core/normalize.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeV6Groups } from '../../src/core/normalize';
+
+describe('IPv6 normalization', () => {
+  it('compress longest zero run (leftmost on tie)', () => {
+    // example: 2001:0db8:0000:0000:0000:0000:1428:57ab -> 2001:db8::1428:57ab
+    const groups = [0x2001, 0x0db8, 0, 0, 0, 0, 0x1428, 0x57ab];
+    const { text } = normalizeV6Groups(groups);
+    expect(text).toBe('2001:db8::1428:57ab');
+  });
+
+  it('no compress single zero group', () => {
+    const groups = [0x2001, 0xdb8, 0, 1, 2, 3, 4, 5];
+    const { text } = normalizeV6Groups(groups);
+    expect(text).toBe('2001:db8:0:1:2:3:4:5');
+  });
+
+  it('ipv4 mapped detection', () => {
+    const groups = [0, 0, 0, 0, 0, 0xffff, 0xc0a8, 0x0101]; // ::ffff:192.168.1.1
+    const { text, mappedV4 } = normalizeV6Groups(groups);
+    expect(mappedV4).toBe('192.168.1.1');
+    expect(text).toContain('::ffff');
+  });
+});

--- a/tests/core/ptr.test.ts
+++ b/tests/core/ptr.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { ptrV4, ptrV6, ptrZonesForCIDR } from '../../src/core/ptr';
+
+describe('ptr utils', () => {
+  it('ptrV4 basic', () => {
+    expect(ptrV4(0xc0a80101n)).toBe('1.1.168.192.in-addr.arpa');
+  });
+
+  it('ptrV6 basic', () => {
+    // ::1 -> nibble representation ends with 1
+    expect(ptrV6(1n)).toContain('ip6.arpa');
+  });
+
+  it('ptrZonesForCIDR ipv4 /24', () => {
+    const zones = ptrZonesForCIDR(0xc0a80101n, 24, 32);
+    expect(zones.length).toBeGreaterThan(0);
+    expect(zones[0]).toContain('in-addr.arpa');
+  });
+
+  it('ptrZonesForCIDR ipv6 nibble', () => {
+    const zones = ptrZonesForCIDR(0x20010db8000000000000000000000001n, 32, 128);
+    expect(zones.length).toBeGreaterThan(0);
+    expect(zones[0]).toContain('ip6.arpa');
+  });
+});

--- a/tests/core/ptr.test.ts
+++ b/tests/core/ptr.test.ts
@@ -7,8 +7,10 @@ describe('ptr utils', () => {
   });
 
   it('ptrV6 basic', () => {
-    // ::1 -> nibble representation ends with 1
-    expect(ptrV6(1n)).toContain('ip6.arpa');
+  // ::1 -> nibble representation LSB-first should start with '1' then 31 '0' nibbles
+  const got = ptrV6(1n);
+  const expected = '1.' + new Array(31).fill('0').join('.') + '.ip6.arpa';
+  expect(got).toBe(expected);
   });
 
   it('ptrZonesForCIDR ipv4 /24', () => {

--- a/tests/domain/cidr-subnets.test.ts
+++ b/tests/domain/cidr-subnets.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { CIDR } from '../../src/domain/cidr';
+
+describe('CIDR subnets and split', () => {
+  it('/24 -> /26 subnets', () => {
+    const c = CIDR.parse('192.168.0.0/24') as any as CIDR<4>;
+    const subs = Array.from(c.subnets(26));
+    expect(subs.length).toBe(4);
+    expect(subs[0].prefix).toBe(26);
+    expect(subs[1].network().toString()).toBe('192.168.0.64');
+  });
+
+  it('split parts=3 returns first 3 of /26', () => {
+    const c = CIDR.parse('192.168.0.0/24') as any as CIDR<4>;
+    const parts = c.split(3);
+    expect(parts.length).toBe(3);
+    expect(parts[0].prefix).toBe(26);
+  });
+
+  it('ipv6 /64 -> /66 subnets', () => {
+    const c = CIDR.parse('2001:db8::/64') as any as CIDR<6>;
+    const subs = Array.from(c.subnets(66));
+    expect(subs.length).toBe(4);
+    expect(subs[0].prefix).toBe(66);
+  });
+});

--- a/tests/domain/range-toCIDRs.test.ts
+++ b/tests/domain/range-toCIDRs.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { IPRange } from '../../src/domain/range';
+
+describe('IPRange toCIDRs', () => {
+  it('single-aligned range /24', () => {
+    const r = IPRange.parse('192.168.0.0-192.168.0.255');
+    const cidrs = r.toCIDRs();
+    expect(cidrs.length).toBe(1);
+    expect(cidrs[0].prefix).toBe(24);
+  });
+
+  it('small range that needs multiple cidrs', () => {
+    const r = IPRange.parse('192.168.0.5-192.168.0.20');
+    const cidrs = r.toCIDRs();
+    // Coverage size should equal original range size
+    const covered = cidrs.reduce((sum, c) => sum + c.size(), 0n);
+    expect(covered).toBe(r.size());
+  });
+
+  it('single IP becomes /32', () => {
+    const r = IPRange.parse('10.0.0.1-10.0.0.1');
+    const cidrs = r.toCIDRs();
+    expect(cidrs.length).toBeGreaterThan(0);
+    expect(cidrs[0].prefix).toBe(32);
+  });
+});

--- a/tests/domain/trie-lpm.test.ts
+++ b/tests/domain/trie-lpm.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { RadixTrie } from '../../src/domain/trie';
+import { CIDR } from '../../src/domain/cidr';
+import { IPv4 } from '../../src/domain/ip';
+
+describe('RadixTrie LPM behaviors', () => {
+  it('longest prefix when /8 and /16 overlap', () => {
+  const trie = new RadixTrie(4);
+  trie.insert(CIDR.parse('10.0.0.0/8') as any as CIDR<4>, 'a');
+  trie.insert(CIDR.parse('10.1.0.0/16') as any as CIDR<4>, 'b');
+
+  const match1 = trie.longestMatch(IPv4.parse('10.1.2.3') as any);
+    expect(match1).not.toBeNull();
+    expect(match1!.value).toBe('b');
+
+  const match2 = trie.longestMatch(IPv4.parse('10.2.2.3') as any);
+    expect(match2).not.toBeNull();
+    expect(match2!.value).toBe('a');
+  });
+
+  it('remove a CIDR and ensure longestMatch falls back', () => {
+    const trie = new RadixTrie(4);
+  trie.insert(CIDR.parse('192.0.2.0/24') as any as CIDR<4>, 'x');
+  expect(trie.longestMatch(IPv4.parse('192.0.2.1') as any)!.value).toBe('x');
+  trie.remove(CIDR.parse('192.0.2.0/24') as any as CIDR<4>);
+  expect(trie.longestMatch(IPv4.parse('192.0.2.1') as any)).toBeNull();
+  });
+});


### PR DESCRIPTION
- Core bigint and helpers
  - Fixed alignment and mask helpers to be BigInt-safe.
  - Replaced generic RangeError throws with `OutOfRangeError` where appropriate.

- IPv6 normalization & PTR fixes
  - RFC5952 normalization fixes and improved v4-mapped handling.
  - Fixed reverse PTR generation for IPv4/IPv6.

- CIDR, Range and RangeSet
  - Implemented BigInt-safe `CIDR.subnets()` and `CIDR.split()`.
  - Implemented `IPRange.toCIDRs()` minimal-cover algorithm.
  - `RangeSet` normalization and factories improved.

- Allocator
  - Refactored to use `RangeSet` API and added BigInt-safe `utilization()` to avoid overflow for IPv6.
  - Improved free-block finder and `nextAvailable()` behaviour.

- RadixTrie
  - Store network bigint on nodes, fix reconstruction and typing issues, and ensure LPM correctness.
  - Small typing/cleanup changes to remove unsafe any-casts.

- Docs, README & examples
  - Added `docs/IP_CALCULATIONS.md` explaining IP math and algorithms.
  - Updated `README.md` with system requirements (Node >= 18 / BigInt), generator guidance, memory/perf caveats (call out `split()`), errors & types note, and explicit test/dev commands.
  - Updated `examples/basic.ts` and `examples/basic.js` to prefer generator patterns, demonstrate `Allocator.utilization()` and `firstHost()/lastHost()` semantics.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Allocator (allocation/utilization APIs), RangeSet.toArray, and expanded ip() input handling (number/bigint/Uint8Array); examples demonstrate generator-based, memory-efficient iteration and an Allocator demo.
- Bug Fixes
  - Stricter error handling and BigInt-safe arithmetic across subnet/split, range→CIDR, normalization, reverse-DNS zones, PTR output, and trie LPM behavior.
- Documentation
  - Major README overhaul, new IP Calculations guide, updated examples, prerequisites (BigInt, package managers), and memory-use warnings/recommendations.
- Tests
  - New unit suites for bigint utilities, IPv6 normalization, PTR utilities, CIDR subnets/split, range→CIDR, trie LPM, and related behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->